### PR TITLE
feat: simplified deployment process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM crystallang/crystal:0.27.2
 
+RUN apt-get update && apt-get upgrade libsqlite3-dev -yqq && apt-get clean
 # Add the app and build it
 WORKDIR /app/
 ADD . /app
-ARG CRYSTAL_ENV=production
+ENV CRYSTAL_ENV=production
 RUN shards build --production --release --no-debug --progress --stats
 
 # Run server by default
-CMD ["bin/server"]
+CMD ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -29,25 +29,30 @@ Clone this repository with
 
 Crystal is a compiled language. It has different compilation modes, e.g. development and production. Production code is faster and packed into a single binary, however its builds take more time. Therefore, there are multiple ways to proceed:
 
-### Production build with Docker
+### Production build with Docker-compose
 
-1. Build an image:
+1. Edit the `docker-compose.yml` file if you want to specify a JWT key, or a
+   custom database location. For example:
 
-```sh
-> docker build -t crystalworld:latest .
+```yaml
+version: '3.5'
+
+services:
+  crystalworld:
+    build: .
+    volumes: [ 'crystalworld_db:/app/crystalworld.db' ]
+    environment:
+      DATABASE_URL: sqlite3://./crystalworld.db
+      JWT_SECRET_KEY: 4bd43eaef50cc962865082160fcd5a96
+    ports:
+      - 5000:5000
+
+volumes:
+  crystalworld_db:
 ```
-2. Apply migrations:
 
-```sh
-> docker run -e DATABASE_URL="sqlite3://./crystalworld.db" crystalworld bin/cake db:migrate
-```
-
-3. Launch the server
-
-```sh
-> docker run -p 5000:5000 -e DATABASE_URL="sqlite3://./crystalworld.db" \
--e JWT_SECRET_KEY="63a051d73d71c997d38946f82e708301" crystalworld
-```
+2. Run `docker-compose up -d --build && docker-compose logs -f` to deploy and
+   watch the logs.
 
 ### Production build from the source code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  crystalworld:
+    build: .
+    volumes: [ 'crystalworld_db:/app/crystalworld.db' ]
+    ports:
+      - 5000:5000
+
+volumes:
+  crystalworld_db:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eux
+
+project_dir=$(dirname $(realpath "docker-entrypoint.sh"))
+
+run() {
+	DATABASE_URL=$1 JWT_SECRET_KEY=$2 $project_dir/bin/server
+}
+
+migrate() {
+	DATABASE_URL=$1 $project_dir/bin/cake db:migrate
+}
+
+# the number of hex digits in the JWT secret
+jwt_size=${jwt_size:-16}
+
+# allows overriding the random generation script
+gen_jwt=${gen_jwt:-"crystal eval puts Random::Secure.hex 16"}
+
+# Set the JWT to either the given value of $JWT_SECRET_KEY or the evaluation of the
+# command stored in the $gen_jwt variable
+JWT_SECRET_KEY=${JWT_SECRET_KEY:-"$($gen_jwt)"}
+
+DATABASE_URL=${DATABASE_URL:-"sqlite3://./crystalworld.db"}
+db_proto=$(printf $DATABASE_URL | sed -rn 's_^(\w+://).+$_\1_p')
+# In the case of SQLite the rest of the URL is the filepath
+rest_of_url=$(printf $DATABASE_URL | sed 's_^\w+://__')
+
+# if there's no file at the location specifed by $DATABASE_URL
+if ! [ -f $rest_of_url ]; then
+  if [ $db_proto = "sqlite3://" ]; then
+    migrate $DATABASE_URL
+	else
+		echo "unsupported database protocol $db_proto"
+		exit 64
+  fi
+fi
+
+run $DATABASE_URL $JWT_SECRET_KEY

--- a/src/bin/server.cr
+++ b/src/bin/server.cr
@@ -40,5 +40,8 @@ end
 Onyx.logger.info("Welcome to the " + "Crystal World!".colorize.mode(:bold).to_s + " © Vlad Faust <mail@vladfaust.com>")
 Onyx.logger.info("For updates visit " + "https://github.com/vladfaust/crystalworld".colorize(:light_gray).to_s)
 
-Onyx.render(:json)
-Onyx.listen
+Onyx.render :json
+
+Onyx.listen(
+  host: ENV.fetch("ONYX_HOST", default: "0.0.0.0"),
+  port: ENV.fetch("ONYX_PORT", default: 5000).to_i)


### PR DESCRIPTION
I added a `docker-entrypoint.sh` which provides a default for the database url and JWT secret. This allows deployment to be simplified to a one liner like `git clone ... && cd crystalworld && docker-compose up ...`

Additionally, (perhaps this should be a separate PR) if you deploy it in docker by default it's not available outside the docker network because Onyx only binds to localhost. This allows overriding the host and port values from environment variables.